### PR TITLE
1.0.0-beta.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.0-beta.8
+* Made the existing sync loops capable of reading the new data containing newlines
+
 ## 1.0.0-beta.7
 * Re-added the newline normalization to the XML string to ensure proper parsing (It somehow vanished in the last commit)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shairport-sync-reader-simple",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "description": "A simple node program to extract shairport-sync metadata via a pipe",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,14 +20,11 @@ export default class ShairportSyncReaderSimple {
   private isProcessing = false;
 
   private handleData(data: string) {
-    this.xml += data;
+    this.xml += data.replace(/\r?\n|\r/g, '');
 
     if (this.isProcessing) return;
 
     this.isProcessing = true;
-
-    // Normalize the XML string by removing line breaks
-    this.xml = this.xml.replace(/\r?\n|\r/g, '');
 
     const itemRegex = /<item><type>(.*?)<\/type><code>(.*?)<\/code><length>(\d+)<\/length><data encoding="base64">(.*?)<\/data><\/item>/g;
     let match;


### PR DESCRIPTION
## 1.0.0-beta.8
* Made the existing sync loops capable of reading the new data containing newlines
