### PR TITLE
1.0.0-beta.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.0-beta.9
+* Fixed a bug causing some metadata to be lost due to incorrect XML processing (it would remain on the XML string indefinitely, which was also (in theory) causing memory leaks)
+
 ## 1.0.0-beta.8
 * Made the existing sync loops capable of reading the new data containing newlines
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shairport-sync-reader-simple",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "description": "A simple node program to extract shairport-sync metadata via a pipe",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ export default class ShairportSyncReaderSimple {
       }
 
       // Remove the processed item from the XML
-      this.xml = this.xml.replace(fullMatch, '');
+      this.xml = this.xml.substring(this.xml.indexOf(fullMatch) + fullMatch.length);
     }
 
     this.isProcessing = false;


### PR DESCRIPTION
## 1.0.0-beta.9
* Fixed a bug causing some metadata to be lost due to incorrect XML processing (it would remain on the XML string indefinitely, which was also (in theory) causing memory leaks)
